### PR TITLE
Fix repl variable `me` atrribute error in dms

### DIFF
--- a/jishaku/repl/repl_builtins.py
+++ b/jishaku/repl/repl_builtins.py
@@ -87,7 +87,7 @@ def get_var_dict_from_ctx(ctx: commands.Context, prefix: str = '_'):
         'find': discord.utils.find,
         'get': discord.utils.get,
         'guild': ctx.guild,
-        'me': ctx.guild.me,
+        'me': ctx.me,
         'http_get_bytes': http_get_bytes,
         'http_get_json': http_get_json,
         'http_post_bytes': http_post_bytes,


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
title

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->
ctx.guild.me -> ctx.me

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [ ] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
